### PR TITLE
Fix: Replace deprecated async_forward_entry_setup with async_forward_entry_setups to support multiple platforms

### DIFF
--- a/custom_components/netzooe_eservice/__init__.py
+++ b/custom_components/netzooe_eservice/__init__.py
@@ -10,7 +10,7 @@ from .const import DOMAIN
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NetzOÖ eService from a config entry."""
-    
+
     username = entry.data["username"]
     password = entry.data["password"]
 
@@ -22,9 +22,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN] = {}
 
     hass.data[DOMAIN][entry.entry_id] = api
-    
+
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, Platform.SENSOR)
+        hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
     )
 
     return True
@@ -32,7 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, Platform.SENSOR):
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, [Platform.SENSOR]):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok


### PR DESCRIPTION
to fix issue with latest 2025.6.0

```
2025-06-12 14:37:01.766 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry eService xx@xxx.at for netzooe_eservice
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 749, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/netzooe_eservice/__init__.py", line 27, in async_setup_entry
    hass.config_entries.async_forward_entry_setup(entry, Platform.SENSOR)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'. Did you mean: 'async_forward_entry_setups'?
```